### PR TITLE
Setting startup to have public methods

### DIFF
--- a/UKHO.ConfigurableStub.Stub/Startup.cs
+++ b/UKHO.ConfigurableStub.Stub/Startup.cs
@@ -25,16 +25,16 @@ namespace UKHO.ConfigurableStub.Stub
 {
     internal class Startup
     {
-        internal Startup(ILoggerFactory loggerFactory)
+        public Startup(ILoggerFactory loggerFactory)
         {
         }
 
-        internal void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             services.AddRouting();
         }
 
-        internal void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
In the previous release I broke the stub by setting some of the startup methods to private. This is to fix that.